### PR TITLE
Changes to C Makefile

### DIFF
--- a/CaseStudies/glass/src/C/Makefile
+++ b/CaseStudies/glass/src/C/Makefile
@@ -30,12 +30,11 @@ all: prog
 
 .PHONY: prog
 prog: $(PROG_TARGET) 
-	$(PROG_TARGET) infile
+	./$(PROG_TARGET) infile
 
 $(PROG_TARGET):
-	$(C_COMPILER) $(CFLAGS) $(SRC_FILES) -o $(PROG_TARGET)
+	$(C_COMPILER) $(CFLAGS) $(SRC_FILES) -o $(PROG_TARGET) -lm
 
 .PHONY: clean
 clean:
 	@-$(RM) $(PROG_TARGET)
-

--- a/CaseStudies/glass/src/C/Makefile
+++ b/CaseStudies/glass/src/C/Makefile
@@ -37,4 +37,4 @@ $(PROG_TARGET):
 
 .PHONY: clean
 clean:
-	@-$(RM) $(PROG_TARGET)
+	@-$(RM) $(PROG_TARGET) outputfile.txt

--- a/CaseStudies/glass/src/C/Makefile
+++ b/CaseStudies/glass/src/C/Makefile
@@ -39,4 +39,4 @@ $(PROG_TARGET):
 
 .PHONY: clean
 clean:
-	@-$(RM) $(PROG_TARGET) outputfile.txt
+	@-$(RM) "$(PROG_TARGET)" "outputfile.txt"

--- a/CaseStudies/glass/src/C/Makefile
+++ b/CaseStudies/glass/src/C/Makefile
@@ -20,6 +20,8 @@ C_COMPILER=gcc
 
 CFLAGS = -std=c99
 
+LINKED_LIBS = -lm
+
 SRC_FILES=$(wildcard src/*.c)
 
 PROG_NAME=glassbr
@@ -33,7 +35,7 @@ prog: $(PROG_TARGET)
 	./$(PROG_TARGET) infile
 
 $(PROG_TARGET):
-	$(C_COMPILER) $(CFLAGS) $(SRC_FILES) -o $(PROG_TARGET) -lm
+	$(C_COMPILER) $(CFLAGS) $(SRC_FILES) -o $(PROG_TARGET) $(LINKED_LIBS)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
I found that the Makefile for the C implementation contained errors, so I changed a couple of lines to fix it.  Specifically:
- I added the `-lm` keyword to the compile instructions.  This is requried to link the `math.h` header, which is used by the program.
- I added a `./` before the name of the executable in the command to execute it.  This is required to execute a file from the command line.
- I also added `output.txt` to the list of files to be removed when `make clean` is run.